### PR TITLE
Change riot to peer dependency, include v3

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
   },
   "homepage": "https://github.com/any-code/riot-i18n#readme",
   "devDependencies": {
-    "nodeunit": "^0.9.1"
+    "nodeunit": "^0.9.1",
+    "riot": "^3.4.2"
   },
   "peerDependencies": {
     "riot": "^2.3.11 || ^3.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   "devDependencies": {
     "nodeunit": "^0.9.1"
   },
-  "dependencies": {
-    "riot": "^2.3.11"
+  "peerDependencies": {
+    "riot": "^2.3.11 || ^3.0.0"
   }
 }


### PR DESCRIPTION
### Proposal
The change here: https://github.com/any-code/riot-i18n/pull/6 added support for `riot@3.x.x`, however didn't allow it as a version range for the package. 

This results in packages using `riot-i18n` and `riot@3.x.x` bundling both versions 2 and 3 of `riot`.

E.G: 
```shell
$ yarn list riot
yarn list v0.22.0
├─ riot-i18n@0.2.1
│  └─ riot@2.6.7
└─ riot@3.4.1
✨  Done in 1.63s.
```

Moved `riot` to a peerDependency so the consumer can specify a semver compliant version.

An alternative would be to publish two separate major versions, matching riot versioning.